### PR TITLE
:fire: remove checkout step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,9 +45,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Checkout branch
-      uses: actions/checkout@v2.4.0
-
     - name: Setup dotnet
       uses: actions/setup-dotnet@v1
       with:


### PR DESCRIPTION
After a bit of looking around I realised that most workflows use
`checkout` by default, and that most of the popular actions expect you
to do so anyway.

I'm following into those footsteps by removing this action.
